### PR TITLE
refactor: use `whiskers` to generate CSS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,3 +32,7 @@ trim_trailing_whitespace = false
 # windows shell scripts
 [*.{cmd,bat,ps1}]
 end_of_line = crlf
+
+# make
+[Makefile]
+indent_style=tab

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all clean
+
+flavours := latte frappe macchiato mocha
+
+all: $(flavours)
+
+$(flavours):
+	whiskers template/style.css $@ > "flavors/$@.css"
+
+clean:
+	rm -fv flavors/*.css

--- a/flavors/frappe.css
+++ b/flavors/frappe.css
@@ -1,32 +1,31 @@
 :root {
-  --text: #c6d0f5; /* Text */
-  --text-muted: #a5adce; /* Subtext0 */
-  --text-hover: var(--text);
-  --label-text-color: #fff; /* have to break convention here */
+  --main-bg-color: #303446;
 
-  --main-bg-color: #303446; /* Base */
+  --modal-bg-color: #292c3c;
+  --modal-header-color: #232634;
+  --modal-footer-color: #232634;
 
-  --modal-bg-color: #292c3c; /* Mantle */
-  --modal-header-color: #232634; /* Crust */
-  --modal-footer-color: #232634; /* Crust */
+  --drop-down-menu-bg: #414559;
 
-  --drop-down-menu-bg: #414559; /* Surface0 */
-
-  --button-color: #414559; /* Surface0 */
-  --button-color-hover: #51576d; /* Surface1 */
+  --button-color: #414559;
+  --button-color-hover: #51576d;
   --button-text: var(--text);
   --button-text-hover: var(--text-hover);
 
-  --accent-color: 137, 180, 250; /* Blue */
+  --accent-color: 137, 180, 250; /* Mocha Blue */
   --accent-color-hover: rgb(var(--accent-color), 0.8);
   --link-color: var(--text);
-  --link-color-hover: #8caaee; /* Blue */
+  --link-color-hover: #8caaee;
+  --label-text-color: #fff; /* have to break convention here */
+
+  --text: #c6d0f5;
+  --text-hover: var(--text);
+  --text-muted: a5adce;
 
   /* Specials */
-  --arr-queue-color: #a6d189; /* Servarr apps + Bazarr */ /* Green */
-  --plex-poster-unwatched: #ef9f76; /* Peach */
-  --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg)
-    brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
+  --arr-queue-color: #a6d189; /* Servarr apps + Bazarr */
+  --plex-poster-unwatched: #ef9f76;
+  --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg) brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
   --gitea-color-primary-dark-4: var(--accent-color);
   --overseerr-gradient: linear-gradient(
     var(--main-bg-color),

--- a/flavors/latte.css
+++ b/flavors/latte.css
@@ -1,32 +1,31 @@
 :root {
-  --text: #4c4f69; /* Text */
-  --text-muted: #6c6f85; /* Subtext0 */
-  --text-hover: var(--text);
-  --label-text-color: #fff; /* have to break convention here */
+  --main-bg-color: #eff1f5;
 
-  --main-bg-color: #eff1f5; /* Base */
+  --modal-bg-color: #e6e9ef;
+  --modal-header-color: #dce0e8;
+  --modal-footer-color: #dce0e8;
 
-  --modal-bg-color: #e6e9ef; /* Mantle */
-  --modal-header-color: #dce0e8; /* Crust */
-  --modal-footer-color: #dce0e8; /* Crust */
+  --drop-down-menu-bg: #ccd0da;
 
-  --drop-down-menu-bg: #ccd0da; /* Surface0 */
-
-  --button-color: #ccd0da; /* Surface0 */
-  --button-color-hover: #bcc0cc; /* Surface1 */
+  --button-color: #ccd0da;
+  --button-color-hover: #bcc0cc;
   --button-text: var(--text);
   --button-text-hover: var(--text-hover);
 
-  --accent-color: 137, 180, 250; /* Blue */
+  --accent-color: 137, 180, 250; /* Mocha Blue */
   --accent-color-hover: rgb(var(--accent-color), 0.8);
   --link-color: var(--text);
-  --link-color-hover: #1e66f5; /* Blue */
+  --link-color-hover: #1e66f5;
+  --label-text-color: #fff; /* have to break convention here */
+
+  --text: #4c4f69;
+  --text-hover: var(--text);
+  --text-muted: 6c6f85;
 
   /* Specials */
-  --arr-queue-color: #40a02b; /* Servarr apps + Bazarr */ /* Green */
-  --plex-poster-unwatched: #fe640b; /* Peach */
-  --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg)
-    brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
+  --arr-queue-color: #40a02b; /* Servarr apps + Bazarr */
+  --plex-poster-unwatched: #fe640b;
+  --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg) brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
   --gitea-color-primary-dark-4: var(--accent-color);
   --overseerr-gradient: linear-gradient(
     var(--main-bg-color),

--- a/flavors/macchiato.css
+++ b/flavors/macchiato.css
@@ -1,32 +1,31 @@
 :root {
-  --text: #cad3f5; /* Text */
-  --text-muted: #a5adcb; /* Subtext0 */
-  --text-hover: var(--text);
-  --label-text-color: #fff; /* have to break convention here */
+  --main-bg-color: #24273a;
 
-  --main-bg-color: #24273a; /* Base */
+  --modal-bg-color: #1e2030;
+  --modal-header-color: #181926;
+  --modal-footer-color: #181926;
 
-  --modal-bg-color: #1e2030; /* Mantle */
-  --modal-header-color: #181926; /* Crust */
-  --modal-footer-color: #181926; /* Crust */
+  --drop-down-menu-bg: #363a4f;
 
-  --drop-down-menu-bg: #363a4f; /* Surface0 */
-
-  --button-color: #363a4f; /* Surface0 */
-  --button-color-hover: #494d64; /* Surface1 */
+  --button-color: #363a4f;
+  --button-color-hover: #494d64;
   --button-text: var(--text);
   --button-text-hover: var(--text-hover);
 
-  --accent-color: 137, 180, 250; /* Blue */
+  --accent-color: 137, 180, 250; /* Mocha Blue */
   --accent-color-hover: rgb(var(--accent-color), 0.8);
   --link-color: var(--text);
-  --link-color-hover: #8aadf4; /* Blue */
+  --link-color-hover: #8aadf4;
+  --label-text-color: #fff; /* have to break convention here */
+
+  --text: #cad3f5;
+  --text-hover: var(--text);
+  --text-muted: a5adcb;
 
   /* Specials */
-  --arr-queue-color: #a6da95; /* Servarr apps + Bazarr */ /* Green */
-  --plex-poster-unwatched: #f5a97f; /* Peach */
-  --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg)
-    brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
+  --arr-queue-color: #a6da95; /* Servarr apps + Bazarr */
+  --plex-poster-unwatched: #f5a97f;
+  --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg) brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
   --gitea-color-primary-dark-4: var(--accent-color);
   --overseerr-gradient: linear-gradient(
     var(--main-bg-color),

--- a/template/style.css
+++ b/template/style.css
@@ -1,30 +1,30 @@
 :root {
-  --main-bg-color: #1e1e2e;
+  --main-bg-color: #{{base}};
 
-  --modal-bg-color: #181825;
-  --modal-header-color: #11111b;
-  --modal-footer-color: #11111b;
+  --modal-bg-color: #{{mantle}};
+  --modal-header-color: #{{crust}};
+  --modal-footer-color: #{{crust}};
 
-  --drop-down-menu-bg: #313244;
+  --drop-down-menu-bg: #{{surface0}};
 
-  --button-color: #313244;
-  --button-color-hover: #45475a;
+  --button-color: #{{surface0}};
+  --button-color-hover: #{{surface1}};
   --button-text: var(--text);
   --button-text-hover: var(--text-hover);
 
   --accent-color: 137, 180, 250; /* Mocha Blue */
   --accent-color-hover: rgb(var(--accent-color), 0.8);
   --link-color: var(--text);
-  --link-color-hover: #89b4fa;
+  --link-color-hover: #{{blue}};
   --label-text-color: #fff; /* have to break convention here */
 
-  --text: #cdd6f4;
+  --text: #{{text}};
   --text-hover: var(--text);
-  --text-muted: a6adc8;
+  --text-muted: {{subtext0}};
 
   /* Specials */
-  --arr-queue-color: #a6e3a1; /* Servarr apps + Bazarr */
-  --plex-poster-unwatched: #fab387;
+  --arr-queue-color: #{{green}}; /* Servarr apps + Bazarr */
+  --plex-poster-unwatched: #{{peach}};
   --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg) brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
   --gitea-color-primary-dark-4: var(--accent-color);
   --overseerr-gradient: linear-gradient(


### PR DESCRIPTION
This PR uses the new [whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers#readme) tool to auto-generate the CSS. 

The template now follows the themes listed in the [community themes repository](https://github.com/themepark-dev/theme.park/tree/master/css/community-theme-options), I plan to upstream the files there to as a solution to #1. 

I'll let this PR sit for a while in case @lewisakura is still active and wants to review this. If the PR starts going stale, I'll merge this :+1: 